### PR TITLE
PIP: fix install with new read function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,9 @@ def find_version(*paths):
     raise RuntimeError('Unable to find version string')
 
 
-def read_description(*paths):
-    """Build a file path from *paths* and return the contents."""
-    with open(os.path.join(*paths), 'r') as f:
-        return f.read()
+def read_description(filename):
+    """Return the contents of filename."""
+    return open(os.path.join(os.path.dirname(__file__), filename)).read()
 
 
 def read_requirements(filename):


### PR DESCRIPTION
Current code is not able to be installed from pip, because it can't read README.md file during install. I got new code from here https://pythonhosted.org/an_example_pypi_project/setuptools.html#setting-up-setup-py